### PR TITLE
Add aarch64 support

### DIFF
--- a/expressions/OCP/default.nix
+++ b/expressions/OCP/default.nix
@@ -93,7 +93,14 @@ let
     '';
 
   # the order of the following includes is critical, but makes utterly zero sense to me. Order discovered by trial and error and hulk smashing the keyboard.
-    pywrapFlags =  builtins.concatStringsSep " " (
+    pywrapFlags = 
+    let
+      system = stdenv.hostPlatform.system;
+      compiler = if system == "x86_64-linux" then "x86_64-unknown-linux-gnu"
+                 else if system == "aarch64-linux" then "aarch64-unknown-linux-gnu"
+                 else (throw "unsupported system ${system}");
+
+    in builtins.concatStringsSep " " (
       map (p: ''-i '' + p) [
         "${rapidjson}/include"
         "${vtk}/include/vtk/"
@@ -101,10 +108,10 @@ let
         "${xorg.libX11.dev}/include"
         "${libglvnd.dev}/include"
         "${stdenv.cc.cc}/include/c++/${stdenv.cc.version}"
-        "${stdenv.cc.cc}/include/c++/${stdenv.cc.version}/x86_64-unknown-linux-gnu"
+        "${stdenv.cc.cc}/include/c++/${stdenv.cc.version}/${compiler}"
         "${glibc.dev}/include"
-        "${stdenv.cc.cc}/lib/gcc/x86_64-unknown-linux-gnu/${stdenv.cc.version}/include-fixed"
-        "${stdenv.cc.cc}/lib/gcc/x86_64-unknown-linux-gnu/${stdenv.cc.version}/include"
+        "${stdenv.cc.cc}/lib/gcc/${compiler}/${stdenv.cc.version}/include-fixed"
+        "${stdenv.cc.cc}/lib/gcc/${compiler}/${stdenv.cc.version}/include"
     ]);
 
     buildPhase = ''

--- a/expressions/cq-kit/default.nix
+++ b/expressions/cq-kit/default.nix
@@ -4,30 +4,21 @@
   , fetchFromGitHub
   , cadquery
   , pytestCheckHook
+  , rich
 }:
 buildPythonPackage rec {
   pname = "cq-kit";
-  rev = "1c9883abab29f86798ff9b4dca28c5b19cfb852b";
-  version = "0.5.0";
+  rev = "ad1e12b919911f1145262d85adf329995f2ed59e";
+  version = "0.5.8";
   src = fetchFromGitHub {
     owner = "michaelgale";
     repo = pname;
     inherit rev;
-    sha256 = "sha256-IkmwS2+OkvX8V8NtD2O4+kcRfU+YtPpWCMSymLFOlLE=";
+    sha256 = "sha256-opk2eESaZoel9Oc8UYi7DsDnMJf623twQ77DHHLzfHo=";
     fetchSubmodules = true;
   };
 
   propagatedBuildInputs = [ cadquery ];
 
-  checkInputs = [ pytestCheckHook ];
-
-  preCheck = ''
-    pushd .
-    cd tests
-  '';
-
-  postCheck = ''
-    popd
-  '';
-
+  checkInputs = [ pytestCheckHook rich ];
 }

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
   outputs = { self, nixpkgs, flake-utils, ... } @ inputs:
     let
       # someone else who can do the testing might want to extend this to other systems
-      systems = [ "x86_64-linux" ];
+      systems = [ "aarch64-linux" "x86_64-linux" ];
     in
       flake-utils.lib.eachSystem systems ( system:
         let


### PR DESCRIPTION
The test of cq-kit fail due to floating point precision:

```
>       assert (-1, 0, 0) in tpts
E       assert (-1, 0, 0) in [(1.0, 0.0, 0.0), (1.0, -7.0, 0.0), (-1.0, 0.0, -8.112842264749469e-17), (-1.0, -7.0, -8.112842264749469e-17), (-8.555669869210992e-17, 0.0, 3.0), (-8.555669869210992e-17, -7.0, 3.0)]
```

