### PR TITLE
build123d hash update and OCCT build bugfix

### DIFF
--- a/expressions/build123d.nix
+++ b/expressions/build123d.nix
@@ -25,7 +25,7 @@
     repo = pname;
     rev = "v${version}";
     deepClone = true;
-    hash = "sha256-2mAOrNyvi7KGzc98hDXgG6I7s+JBNxVIVIvHbO6jtyE=";
+    hash = "sha256-H17SB9nSlSRKBYDWhLIRXv/ya3iutnltF8RxA9PXPpg=";
   };
 in
   buildPythonPackage {

--- a/expressions/opencascade-occt/default.nix
+++ b/expressions/opencascade-occt/default.nix
@@ -60,6 +60,10 @@ in
       url = "https://raw.githubusercontent.com/conda-forge/occt-feedstock/00ff0f68644d9582a4c30c01220e7de0f934d427/recipe/patches/blobfish.patch";
       sha256 = "sha256-5tqkx7W7VBw7qaseFgwBENKbGQ0iUYEL6SJHwGI9L/g=";
     })
+    (fetchpatch {
+      url = "https://github.com/Open-Cascade-SAS/OCCT/commit/7236e83dcc1e7284e66dc61e612154617ef715d6.patch";
+      sha256 = "sha256-NoC2mE3DG78Y0c9UWonx1vmXoU4g5XxFUT3eVXqLU60=";
+    })
   ];
 
   # I've removed the 3RDPARTY_DIR flag, not really sure if it's needed or not


### PR DESCRIPTION
The build123d 0.7.0 tag has a new hash.

There is a bug in `src/StdPrs/StdPrs_BRepFont.cxx` in OCCT 7.7.2 that causes the build to fail. This applies the commit patch as recommended in this Debian Bugs discussion: https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1993992.html