### PR TITLE
yacv: 0.8.11 -> 0.9.2

### DIFF
--- a/expressions/yacv/frontend.nix
+++ b/expressions/yacv/frontend.nix
@@ -5,8 +5,8 @@
 }:
 let
   frontend = fetchzip {
-    url = "https://github.com/yeicor-3d/yet-another-cad-viewer/releases/download/v0.8.11/frontend.zip";
-    hash = "sha256-J57XPF3/1i/DlHYaR06xw6mTWAu8HW7wxFLRtJGl23w=";
+    url = "https://github.com/yeicor-3d/yet-another-cad-viewer/releases/download/v0.9.2/frontend.zip";
+    hash = "sha256-d5qKs9h4q9/hquVgWFb10KSE2gWTSAZQgYo9l0bzdVM=";
   };
 in
   writeShellScriptBin "yacv-frontend" "${python3}/bin/python -m http.server --directory ${frontend}"

--- a/expressions/yacv/server.nix
+++ b/expressions/yacv/server.nix
@@ -9,12 +9,12 @@
   pillow,
 }: let
   pname = "yacv-server";
-  version = "0.8.11";
+  version = "0.9.2";
   src = fetchFromGitHub {
     owner = "yeicor-3d";
     repo = "yet-another-cad-viewer";
     rev = "v${version}";
-    hash = "sha256-p0sxd2NGZplNRYpy82BF5ulGV3OmHiVSOK4AZD5c8zA=";
+    hash = "sha256-4rNwYXjpf462zLf96QgMwPDPwoEyT5QrdUgZ7Run1fU=";
   };
 in
   buildPythonPackage {


### PR DESCRIPTION
Version bump to the latest version compatible with build123d 0.7
Tested on NixOS with nixpkgs-unstable